### PR TITLE
chore: promote chartmuseum to version 2.1.15

### DIFF
--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -5,5 +5,6 @@ helmfiles:
 - path: helmfiles/nginx/helmfile.yaml
 - path: helmfiles/secret-infra/helmfile.yaml
 - path: helmfiles/tekton-pipelines/helmfile.yaml
+- path: helmfiles/jx-staging/helmfile.yaml
 templates: {}
 renderedvalues: {}

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -1,0 +1,11 @@
+filepath: ""
+namespace: jx-staging
+repositories:
+- name: dev
+  url: http://chartmuseum-jx.20.71.9.175.nip.io
+releases:
+- chart: dev/chartmuseum
+  version: 2.1.15
+  name: chartmuseum
+templates: {}
+renderedvalues: {}


### PR DESCRIPTION
chore: promote chartmuseum to version 2.1.15

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
